### PR TITLE
Fix/rerun 11.2

### DIFF
--- a/beyond-lfs/packages/lib/event.md
+++ b/beyond-lfs/packages/lib/event.md
@@ -4,7 +4,7 @@ Why: dependency of `tmux`
 
 installed version: `2.1.12`
 
-time: >1.0x (need to rechec with tests)
+time: 0.74x real (0.28x user+sys)
 
 links:
 
@@ -21,6 +21,4 @@ links:
 
 different name: `verify`
 
-got a lot of errors related to "nameserver" and "lock function", but in the end all 10 tests passed
-
-on `2.1.12` there were test failures, need to recheck
+"6/353 TESTS FAILED"

--- a/beyond-lfs/packages/tmux.md
+++ b/beyond-lfs/packages/tmux.md
@@ -4,7 +4,7 @@ Why: multiple terminals screens
 
 installed version: `3.3a`
 
-time: 0.0x real (0.0x user+sys)
+time: negligible
 
 links:
 

--- a/scripts/packages/bash-tests.sh
+++ b/scripts/packages/bash-tests.sh
@@ -5,7 +5,7 @@ chown -R tester .
 
 time su -s /usr/bin/expect tester << EOF
 set timeout -1
-spawn make tests -k --jobs 4
+spawn make tests --jobs 4
 expect eof
 lassign [wait] _ _ _ value
 exit $value

--- a/scripts/packages/binutils/tests.sh
+++ b/scripts/packages/binutils/tests.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+if make -k check --jobs 1 &>check.log ; then
+  echo "check passed!"
+else
+  echo "check failed"
+  if grep -E "^FAIL" check.log ; then
+    exit 1
+  fi
+  if grep -E "^ERROR" check.log | grep -vE "^ERROR: (compilation of test program in jsynprog|comparison of results in mttest) failed$" ; then
+    exit 1
+  fi
+  echo "but only expected errors"
+fi

--- a/scripts/packages/file-pre-config.sh
+++ b/scripts/packages/file-pre-config.sh
@@ -1,10 +1,8 @@
 #!/usr/bin/env bash
 set -e
 
-build_dir=build
-
-mkdir $build_dir
-pushd $build_dir
+mkdir build
+pushd build
 ../configure \
   --disable-bzlib \
   --disable-libseccomp \

--- a/scripts/packages/gcc/tests.sh
+++ b/scripts/packages/gcc/tests.sh
@@ -8,11 +8,15 @@ echo "starting tests"
 time su tester -c "PATH=$PATH make --jobs 8 -k check || echo 'make check failed'"
 
 echo "failed tests:"
-../contrib/test_summary | grep -E '(XPASS|FAIL)' | sort
+../contrib/test_summary | grep -E '(XPASS|FAIL)' | sort | tee failed-test-summary.log
 echo "# end of FAILed test list"
 
-echo "forcing a break in test script"
-exit 1
+if grep -v "c-c++-common/goacc/kernels-decompose-pr100400-1-2.c" failed-test-summary.log >/dev/null ; then
+  echo "FAIL: there are unexpected failing tests" >&2
+  exit 1
+else
+  echo "only expected failing tests, will continue"
+fi
 
 echo "cleanup permissions"
 chown -R root .

--- a/scripts/packages/libelf-install.sh
+++ b/scripts/packages/libelf-install.sh
@@ -2,4 +2,4 @@
 
 make DESTDIR="$DESTDIR" -C libelf install
 install -vm644 config/libelf.pc "$DESTDIR"/usr/lib/pkgconfig
-rm -v "$DESTDIR"/lib/libelf.a
+rm -v "$DESTDIR"/usr/lib/libelf.a

--- a/steps/1-temp-system.md
+++ b/steps/1-temp-system.md
@@ -24,6 +24,7 @@ Remeber to time the first installed package, since all the others are relative t
         - `scripts/packages/gcc/fix-limits_header.sh`
     - time: 3.9x real (user+sys: 13.7x to 13.9x)
 - Linux API Headers
+    - remove previous extracted linux dir if re-running with same linux version
     - extract from the linux sources (use downloaded version)
     - ensure clean working directory: `make mrproper`
     - build using `make headers`

--- a/steps/1-temp-system.md
+++ b/steps/1-temp-system.md
@@ -39,7 +39,7 @@ Remeber to time the first installed package, since all the others are relative t
 
 ## Sanity Check 1
 
-See `scripts/sanity-check.sh` and run with `SANITY_CC=$LFS_TGT-gcc ./scripts/sanity-check.sh`
+See `scripts/sanity-check.sh` and run with `SANITY_CC=gcc ./scripts/sanity-check.sh`
 
 Finalize `limits.h` header, see `scripts/finalize-limitsh.sh`
 

--- a/steps/3-main-build.md
+++ b/steps/3-main-build.md
@@ -474,7 +474,7 @@ Time: 0.6x real (user+sys: 4.0x)
     - time: negligible
 - util-linux
     - tests:
-        - may be harmful when run as root user, see `scripts/packages/util-linux-tests.sh`
+        - may be harmful when run as root user, see `scripts/packages/util-linux-tests.sh` (to run as `tester`)
         - "1 tests of 225 FAILED"
             - `hardlink/options` ("The hardlink tests will fail if...")
     - time: 0.37x real (user+sys: 1.0x)

--- a/steps/3-main-build.md
+++ b/steps/3-main-build.md
@@ -41,7 +41,7 @@ Tests are *critical*, but some will fail:
 
 `grep '^FAIL' tests.sum` to get a list of failed
 
-See `steps/test-results.md` for my list of failed tests
+See `steps/test-results.md` for summary.
 
 #### Install glibc
 

--- a/steps/3-main-build.md
+++ b/steps/3-main-build.md
@@ -38,11 +38,6 @@ Tests are *critical*, but some will fail:
 - known to fail: (and failed on `2.36` and `2.34`)
     - `io/tst-lchmod`
     - `misc/tst-ttyname`
-- other test failures (on `2.36`)
-    - `nptl/tst-cancel24`
-    - `nptl/tst-minstack-throw`
-    - `nptl/tst-once5`
-    - `nptl/tst-thread-exit-clobber`
 
 `grep '^FAIL' tests.sum` to get a list of failed
 
@@ -135,7 +130,9 @@ First verify PTYs are working in chroot:
 `(expect -c "spawn ls" | grep "spawn ls" && echo "SUCCESS") || echo "FAILED"`
 
 The tests are critical.  
-See `steps/test-results.md` for my list of failed tests
+Had issues on `2.39` when running in parallel, with the failing tests changing
+on reruns (see `steps/test-results.md`)  
+Passes when using `--jobs 1`, though there were build errors in `make check` which caused the step to fail.  
 
 Remove static libs after installing
 

--- a/steps/3-main-build.md
+++ b/steps/3-main-build.md
@@ -474,8 +474,8 @@ Time: 0.6x real (user+sys: 4.0x)
 - util-linux
     - tests:
         - may be harmful when run as root user, see `scripts/packages/util-linux-tests.sh` (to run as `tester`)
-        - "1 tests of 225 FAILED"
-            - `hardlink/options` ("The hardlink tests will fail if...")
+        - "All 225 tests PASSED"
+        - `hardlink/options` ("The hardlink tests will fail if..."), failed initially but passed on re-run
     - time: 0.37x real (user+sys: 1.0x)
 - e2fsprogs
     - tests: "371 tests succeeded     0 tests failed"

--- a/steps/3-main-build.md
+++ b/steps/3-main-build.md
@@ -130,13 +130,13 @@ First verify PTYs are working in chroot:
 `(expect -c "spawn ls" | grep "spawn ls" && echo "SUCCESS") || echo "FAILED"`
 
 The tests are critical.  
-Had issues on `2.39` when running in parallel, with the failing tests changing
-on reruns (see `steps/test-results.md`)  
+Had issues on `2.39` when running in parallel, with the failing tests changing on reruns.  
 Passes when using `--jobs 1`, though there were build errors in `make check` which caused the step to fail.  
+See `./scripts/packages/binutils/tests.sh`
 
 Remove static libs after installing
 
-time: 2.3x real (user+sys: 8.5x)
+time: 3.6x real (user+sys 7.4x) (was 2.3x/8.5x with parallel tests)
 
 ### gmp, mpfr, mpc
 

--- a/steps/3-main-build.md
+++ b/steps/3-main-build.md
@@ -332,7 +332,6 @@ Time: 5.6x to 5.8x real (user+sys: same)
 - libelf
     - in archive: `elfutils-*`
     - tests: 232 total, 227 pass, 5 skipped
-        - `run-backtrace-native.sh` failed
     - install only libelf, see `scripts/packages/libelf-install.sh`
     - time: 0.28x real (user+sys: 0.9x)
 - libffi

--- a/steps/5-bootable.md
+++ b/steps/5-bootable.md
@@ -59,6 +59,7 @@ on the *host* system:
 ln -svf "$LFS/etc/grub.d/11_lfs" /etc/grub.d
 cp -v /boot/grub/grub.cfg /boot/grub/grub.cfg.bak
 grub-mkconfig > /boot/grub/grub.cfg
+diff /boot/grub/grub.cfg /boot/grub/grub.cfg.bak
 ```
 
 ### previous notes

--- a/steps/test-results.md
+++ b/steps/test-results.md
@@ -6,8 +6,8 @@
 
 ```
 Summary of test results:
-      6 FAIL
-   4921 PASS
+      2 FAIL
+   4925 PASS
     234 UNSUPPORTED
      16 XFAIL
       4 XPASS

--- a/steps/test-results.md
+++ b/steps/test-results.md
@@ -39,23 +39,11 @@ Summary of test results:
 
 ### Failed on `2.39`
 
+Failed on parallel builds, with the list of failing tests changing on reruns. Some of the common ones:
+
 - `assignment tests`
 - `.sleb128 tests`
 - `.sleb128 tests (2)`
-- `.sleb128 tests (3)`
-- `Run with libdl3a.so`
-- `Run with libdl3c.so`
-- `eh_test`
-- `exception_shared_1_test`
-- `exception_test`
-- `exception_shared_2_test`
-- `exception_same_shared_test`
-- `exception_separate_shared_21_test`
-- `exception_separate_shared_12_test`
-- `relro_test`
-- `relro_now_test`
-- `relro_strip_test`
-- `exception_x86_64_bnd_test`
 
 ## GCC test failures:
 
@@ -71,14 +59,6 @@ FAIL: c-c++-common/goacc/kernels-decompose-pr100400-1-2.c  -std=c++14 (test for 
 FAIL: c-c++-common/goacc/kernels-decompose-pr100400-1-2.c  -std=c++17 (test for excess errors)
 FAIL: c-c++-common/goacc/kernels-decompose-pr100400-1-2.c  -std=c++20 (test for excess errors)
 FAIL: c-c++-common/goacc/kernels-decompose-pr100400-1-2.c  -std=c++98 (test for excess errors)
-FAIL: gcc.target/x86_64/abi/ms-sysv/ms-sysv.c  -O0 -g3 "-DGEN_ARGS=-p0\\ --omit-rbp-clobbers" (test for excess errors)
-FAIL: gcc.target/x86_64/abi/ms-sysv/ms-sysv.c  -O2 "-DGEN_ARGS=-p0" (test for excess errors)
-FAIL: gcc.target/x86_64/abi/ms-sysv/ms-sysv.c  -O2 "-DGEN_ARGS=-p1" (test for excess errors)
-FAIL: gcc.target/x86_64/abi/ms-sysv/ms-sysv.c  -O2 "-DGEN_ARGS=-p5" (test for excess errors)
-FAIL: gcc.target/x86_64/abi/ms-sysv/ms-sysv.c -mcall-ms2sysv-xlogues -O0 -g3 "-DGEN_ARGS=-p0\\ --omit-rbp-clobbers" (test for excess errors)
-FAIL: gcc.target/x86_64/abi/ms-sysv/ms-sysv.c -mcall-ms2sysv-xlogues -O2 "-DGEN_ARGS=-p0" (test for excess errors)
-FAIL: gcc.target/x86_64/abi/ms-sysv/ms-sysv.c -mcall-ms2sysv-xlogues -O2 "-DGEN_ARGS=-p1" (test for excess errors)
-FAIL: gcc.target/x86_64/abi/ms-sysv/ms-sysv.c -mcall-ms2sysv-xlogues -O2 "-DGEN_ARGS=-p5" (test for excess errors)
 XPASS: c-c++-common/goacc/kernels-decompose-pr100400-1-2.c  -std=c++14 (internal compiler error)
 XPASS: c-c++-common/goacc/kernels-decompose-pr100400-1-2.c  -std=c++17 (internal compiler error)
 XPASS: c-c++-common/goacc/kernels-decompose-pr100400-1-2.c  -std=c++20 (internal compiler error)


### PR DESCRIPTION
updated notes and test results after fixing 11.2 build (typo in disable config command)

- add scripts to help testing binutils, gcc, ignoring known/expected failures

fixes #19 